### PR TITLE
If debug is on, then output the request data that was sent.

### DIFF
--- a/lib/client.php
+++ b/lib/client.php
@@ -72,13 +72,6 @@ class RestClient {
      */
     protected function _logtofile($data) {
         if (!empty(self::$settings->logfilePath) && file_exists(self::$settings->logfilePath . "/")) {
-            /*
-            $t             = microtime(true);
-            $micro         = sprintf("%06d", ($t - floor($t)) * 1000000);
-            $d             = new DateTime(date('Y-m-d H:i:s.' . $micro, $t));
-            $logDate       =;
-            $logEntry      = date("Y/m/d H:i:s") . "  $message\n";
-            */
             file_put_contents(
                 self::$settings->logfilePath . "/" . date("Y-m-d") . ".log",
                 date("Y-m-d H:i:s") . '  ' . (is_array($data) ? print_r($data) : trim($data)) . "\n",
@@ -99,11 +92,11 @@ class RestClient {
                 print("<script>console.log(");
                 is_array($data) ? print_r($data) : print($data);
                 print(");</script>\n\n");
+                is_array($data) ? (print_r($data) && print("\n")) : print($data . "\n");
             }
             if (!empty(self::$settings->logfilePath)) {
                 $this->_logtofile($data);
             }
-            is_array($data) ? (print_r($data) && print("\n")) : print($data . "\n");
         }
     }
 
@@ -136,9 +129,11 @@ class RestClient {
                 $this->_console("Server Response:\n");
                 $this->_console($response['Response']);
             }
-            return $response['Message'];
+            return array('error' => $response['Message']);
         }
-        return $response['Response'];
+        else {
+            return $response['Response'];
+        }
     }
 
 
@@ -165,6 +160,10 @@ class RestClient {
         // First, we try to catch any errors as the request "goes out the door"
         try {
             $response = $this->client->post($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, ['json' => $request]);
+            if (self::$settings->debug){
+                $this->_console("Post Request to $endpoint\n");
+                $this->_console("    " . json_encode($request));
+            }
         }
         catch (RequestException $exception) {
             $response = false;
@@ -205,6 +204,10 @@ class RestClient {
         // First, we try to catch any errors as the request "goes out the door"
         try {
             $response = $this->client->get($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, ['query' => $query]);
+            if (self::$settings->debug){
+                $this->_console("Get Request to $endpoint\n");
+                $this->_console("    " . json_encode($query));
+            }
         }
         catch (RequestException $exception) {
             $response = false;


### PR DESCRIPTION
/lib/client.php:95 - `_console()`
- Only do `print_r()` if browserMessages is enabled (so debug can be turned on and use `_logtofile()`, but not affect output in browser)

/lib/client.php:132 - `_dwollaparse()`
- Return errors in an array so they're different to success messages. (Previously there was no clear way to know whether it had succeeded or not.)

/lib/client.php:163 - `_post()`
- If debug is on then log/echo the request data that was sent (so that if an error occurred you can see what had been sent to cause it.)

/lib/client.php:207 - `_get()`
- Same as for _post()

@mach-kernel - I ran the unit-tests, and they seemed to have worked.