### PR TITLE
fix escaping of variable names in error messages

### DIFF
--- a/lib/checkouts.php
+++ b/lib/checkouts.php
@@ -46,10 +46,10 @@ class Checkouts extends RestClient {
      * @param $quantity {Integer} Product quantity.
      */
     public function addToCart($name, $desc, $cost, $quantity) {
-        if (!$name) { return self::_error("addToCart() requires `$name` parameter.\n"); }
-        if (!$desc) { return self::_error("addToCart() requires `$desc` parameter.\n"); }
-        if (!$cost) { return self::_error("addToCart() requires `$cost` parameter.\n"); }
-        if (!$quantity) { return self::_error("addToCart() requires `$quantity` parameter.\n"); }
+        if (!$name) { return self::_error("addToCart() requires `\$name` parameter.\n"); }
+        if (!$desc) { return self::_error("addToCart() requires `\$desc` parameter.\n"); }
+        if (!$cost) { return self::_error("addToCart() requires `\$cost` parameter.\n"); }
+        if (!$quantity) { return self::_error("addToCart() requires `\$quantity` parameter.\n"); }
 
         if (!is_array($this->cart)) { $this->cart = []; }
 
@@ -76,12 +76,12 @@ class Checkouts extends RestClient {
      */
 
     public function create($purchaseOrder, $params = false) {
-        if (!$purchaseOrder) { return self::_error("create() requires `$purchaseOrder` parameter.\n"); }
+        if (!$purchaseOrder) { return self::_error("create() requires `\$purchaseOrder` parameter.\n"); }
         if (is_array($purchaseOrder)) {
             if (!$purchaseOrder['destinationId']) { return self::_error("`$purchaseOrder` has no `destinationId` key."); }
             if (!$this->cart && !$purchaseOrder['total']) { return self::_error("`$purchaseOrder` has no `total` amount. Create a cart or pass in a total order amount."); }
         }
-        else { return self::_error("createCheckout() requires `$purchaseOrder` to be of type array."); }
+        else { return self::_error("createCheckout() requires `\$purchaseOrder` to be of type array."); }
 
         $p = [
             'client_id' => self::$settings->client_id,
@@ -132,7 +132,7 @@ class Checkouts extends RestClient {
      * @return mixed|null
      */
     public function get($id) {
-        if (!$id) { return self::_error("get() requires `$id` parameter.\n"); }
+        if (!$id) { return self::_error("get() requires `\$id` parameter.\n"); }
 
         return self::_get('/offsitegateway/checkouts/'. $id,
             [
@@ -149,7 +149,7 @@ class Checkouts extends RestClient {
      * @return null
      */
     public function complete($id) {
-        if (!$id) { return self::_error("complete() requires `$id` parameter.\n"); }
+        if (!$id) { return self::_error("complete() requires `\$id` parameter.\n"); }
 
         return self::_post('/offsitegateway/checkouts/' . $id . '/complete',
             [
@@ -169,9 +169,9 @@ class Checkouts extends RestClient {
      * @return {Bool} Check success or failure.
      */
     public function verify($sig, $id, $amount) {
-        if (!$id) { return self::_error("verify() requires `$id` parameter.\n"); }
-        if (!$sig) { return self::_error("verify() requires `$sig` parameter.\n"); }
-        if (!$amount) { return self::_error("verify() requires `$amount` parameter.\n"); }
+        if (!$id) { return self::_error("verify() requires `\$id` parameter.\n"); }
+        if (!$sig) { return self::_error("verify() requires `\$sig` parameter.\n"); }
+        if (!$amount) { return self::_error("verify() requires `\$amount` parameter.\n"); }
 
         // Normalize amount
         $amount = number_format($amount, 2, '.', '');

--- a/lib/contacts.php
+++ b/lib/contacts.php
@@ -48,8 +48,8 @@ class Contacts extends RestClient {
      * @return {Array} Returned spots.
      */
     public function nearby($lat, $lon, $params = false) {
-        if (!$lat) { return self::_error("nearby() requires `$lat` parameter.\n"); }
-        if (!$lon) { return self::_error("nearby() requires `$lon` parameter.\n"); }
+        if (!$lat) { return self::_error("nearby() requires `\$lat` parameter.\n"); }
+        if (!$lon) { return self::_error("nearby() requires `\$lon` parameter.\n"); }
 
         $p = [
             'client_id' => self::$settings->client_id,

--- a/lib/fundingSources.php
+++ b/lib/fundingSources.php
@@ -33,7 +33,7 @@ class fundingSources extends RestClient {
      * @return {Array} Funding ID info.
      */
     public function info($funding_id) {
-        if (!$funding_id) { return self::_error("info() requires `$funding_id` parameter.\n"); }
+        if (!$funding_id) { return self::_error("info() requires `\$funding_id` parameter.\n"); }
 
         return self::_get('/fundingsources/' . $funding_id,
             [
@@ -71,10 +71,10 @@ class fundingSources extends RestClient {
      * @return null
      */
     public function add($account, $routing, $type, $name) {
-        if (!$account) { return self::_error("add() requires `$account` parameter.\n"); }
-        if (!$routing) { return self::_error("add() requires `$routing` parameter.\n"); }
-        if (!$type) { return self::_error("add() requires `$type` parameter.\n"); }
-        if (!$name) { return self::_error("add() requires `$name` parameter.\n"); }
+        if (!$account) { return self::_error("add() requires `\$account` parameter.\n"); }
+        if (!$routing) { return self::_error("add() requires `\$routing` parameter.\n"); }
+        if (!$type) { return self::_error("add() requires `\$type` parameter.\n"); }
+        if (!$name) { return self::_error("add() requires `\$name` parameter.\n"); }
 
         return self::_post('/fundingsources/',
             [
@@ -98,9 +98,9 @@ class fundingSources extends RestClient {
      * @return null
      */
     public function verify($dep1, $dep2, $funding_id) {
-        if (!$dep1) { return self::_error("verify() requires `$dep1` parameter.\n"); }
-        if (!$dep2) { return self::_error("verify() requires `$dep2` parameter.\n"); }
-        if (!$funding_id) { return self::_error("verify() requires `$funding_id` parameter.\n"); }
+        if (!$dep1) { return self::_error("verify() requires `\$dep1` parameter.\n"); }
+        if (!$dep2) { return self::_error("verify() requires `\$dep2` parameter.\n"); }
+        if (!$funding_id) { return self::_error("verify() requires `\$funding_id` parameter.\n"); }
 
         return self::_post('/fundingsources/' . $funding_id . '/verify',
             [
@@ -121,8 +121,8 @@ class fundingSources extends RestClient {
      * @return null
      */
     public function withdraw($amount, $funding_id) {
-        if (!$amount) { return self::_error("withdraw() requires `$amount` parameter.\n"); }
-        if (!$funding_id) { return self::_error("withdraw() requires `$funding_id` parameter.\n"); }
+        if (!$amount) { return self::_error("withdraw() requires `\$amount` parameter.\n"); }
+        if (!$funding_id) { return self::_error("withdraw() requires `\$funding_id` parameter.\n"); }
 
         return self::_post('/fundingsources/' . $funding_id . '/withdraw',
             [
@@ -143,8 +143,8 @@ class fundingSources extends RestClient {
      * @return null
      */
     public function deposit($amount, $funding_id) {
-        if (!$amount) { return self::_error("deposit() requires `$amount` parameter.\n"); }
-        if (!$funding_id) { return self::_error("deposit() requires `$funding_id` parameter.\n"); }
+        if (!$amount) { return self::_error("deposit() requires `\$amount` parameter.\n"); }
+        if (!$funding_id) { return self::_error("deposit() requires `\$funding_id` parameter.\n"); }
 
         return self::_post('/fundingsources/' . $funding_id . '/deposit',
             [

--- a/lib/masspay.php
+++ b/lib/masspay.php
@@ -34,8 +34,8 @@ class MassPay extends RestClient {
      * @return null
      */
     public function create($fundsSource, $items, $params = false) {
-        if (!$fundsSource) { return self::_error("create() requires `$fundsSource` parameter.\n"); }
-        if (!$items) { return self::_error("create() requires `$items` parameter.\n"); }
+        if (!$fundsSource) { return self::_error("create() requires `\$fundsSource` parameter.\n"); }
+        if (!$items) { return self::_error("create() requires `\$items` parameter.\n"); }
 
         $p = [
             'oauth_token' => self::$settings->oauth_token,
@@ -58,7 +58,7 @@ class MassPay extends RestClient {
      * @return null
      */
     public function getJob($id) {
-        if (!$id) { return self::_error("getJob() requires `$id` parameter.\n"); }
+        if (!$id) { return self::_error("getJob() requires `\$id` parameter.\n"); }
 
         return self::_get('/masspay/' . $id,
             [
@@ -75,7 +75,7 @@ class MassPay extends RestClient {
      * @return null
      */
     public function getJobItems($id, $params = false) {
-        if (!$id) { return self::_error("getJobItems() requires `$id` parameter.\n"); }
+        if (!$id) { return self::_error("getJobItems() requires `\$id` parameter.\n"); }
 
         $p = [
             'oauth_token' => self::$settings->oauth_token
@@ -95,8 +95,8 @@ class MassPay extends RestClient {
      * @return null
      */
     public function getItem($job_id, $item_id) {
-        if (!$job_id) { return self::_error("getItem() requires `$job_id` parameter.\n"); }
-        if (!$item_id) { return self::_error("getItem() requires `$item_id` parameter.\n"); }
+        if (!$job_id) { return self::_error("getItem() requires `\$job_id` parameter.\n"); }
+        if (!$item_id) { return self::_error("getItem() requires `\$item_id` parameter.\n"); }
 
         return self::_get('/masspay/' . $job_id . '/items/' . $item_id,
             [

--- a/lib/oauth.php
+++ b/lib/oauth.php
@@ -53,7 +53,7 @@ class OAuth extends RestClient {
      * @return {Array} Access and refresh token pair.
      */
     public function get($code, $redirect = false) {
-        if (!$code) { return self::_error("get() requires `$code` parameter.\n"); }
+        if (!$code) { return self::_error("get() requires `\$code` parameter.\n"); }
 
         $params = [
             'client_id' => self::$settings->client_id,
@@ -74,7 +74,7 @@ class OAuth extends RestClient {
      * @return {Array} Access and refresh token pair.
      */
     public function refresh($refreshToken) {
-        if (!$refreshToken) { return self::_error("refresh() requires `$refreshToken` parameter.\n"); }
+        if (!$refreshToken) { return self::_error("refresh() requires `\$refreshToken` parameter.\n"); }
 
         $params = [
             'client_id' => self::$settings->client_id,

--- a/lib/requests.php
+++ b/lib/requests.php
@@ -35,8 +35,8 @@ class Requests extends RestClient {
      * @return {Integer} Request ID of submitted request.
      */
     public function create($sourceId, $amount, $params = false) {
-        if (!$sourceId) { return self::_error("create() requires `$sourceId` parameter.\n"); }
-        if (!$amount) { return self::_error("create() requires `$amount` parameter.\n"); }
+        if (!$sourceId) { return self::_error("create() requires `\$sourceId` parameter.\n"); }
+        if (!$amount) { return self::_error("create() requires `\$amount` parameter.\n"); }
 
         $p = [
             'oauth_token' => self::$settings->oauth_token,
@@ -76,7 +76,7 @@ class Requests extends RestClient {
      * @return {Array} Information relevant to the request.
      */
     public function info($request_id) {
-        if (!$request_id) { return self::_error("info() requires `$request_id` parameter.\n"); }
+        if (!$request_id) { return self::_error("info() requires `\$request_id` parameter.\n"); }
 
         return self::_get('/requests/' . $request_id,
             [
@@ -92,7 +92,7 @@ class Requests extends RestClient {
      * @return null
      */
     public function cancel($request_id) {
-        if (!$request_id) { return self::_error("cancel() requires `$request_id` parameter.\n"); }
+        if (!$request_id) { return self::_error("cancel() requires `\$request_id` parameter.\n"); }
 
         return self::_post('/requests/' . $request_id . '/cancel',
             [
@@ -110,8 +110,8 @@ class Requests extends RestClient {
      * @return {Array} Information (transaction/request IDs) relevant to fulfilled request.
      */
     public function fulfill($request_id, $amount, $params = false) {
-        if (!$request_id) { return self::_error("fulfill() requires `$request_id` parameter.\n"); }
-        if (!$amount) { return self::_error("fulfill() requires `$amount` parameter.\n"); }
+        if (!$request_id) { return self::_error("fulfill() requires `\$request_id` parameter.\n"); }
+        if (!$amount) { return self::_error("fulfill() requires `\$amount` parameter.\n"); }
 
         $p = [
             'oauth_token' => self::$settings->oauth_token,


### PR DESCRIPTION
variables names are not escaped in most error messages, so it just shows `method() requires '' parameter`