### PR TITLE
Adding mock responses feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dwolla/dwolla-php",
+    "name": "Vasiliskov/dwolla-php",
     "description": "An official Guzzle based wrapper for the Dwolla API.",
     "keywords": ["dwolla", "money", "payments", "api", "orange"],
     "homepage": "http://developers.dwolla.com/",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Vasiliskov/dwolla-php",
+    "name": "Dwolla/dwolla-php",
     "description": "An official Guzzle based wrapper for the Dwolla API.",
     "keywords": ["dwolla", "money", "payments", "api", "orange"],
     "homepage": "http://developers.dwolla.com/",

--- a/lib/_settings.php
+++ b/lib/_settings.php
@@ -39,7 +39,12 @@ class Settings {
     public $rest_timeout = 15;
     public $proxy = false;
 
-   /**
+    // Mocking responses for unit tests
+    public $useMockResponse = false;
+    public $saveMockResponse = false;
+    public $mockResponsesDir = '/tmp/dwolla/';
+
+    /**
      * PHP "magic" getter.
      *
      * @param $name

--- a/lib/client.php
+++ b/lib/client.php
@@ -213,7 +213,7 @@ class RestClient {
      * @return string[] Response body.
      */
     private function _send ($method, $endpoint, $query, $customPostfix = false, $dwollaParse = true) {
-        if (!empty(self::$settings->useMockResponse)) {
+        if (!empty(self::$settings->useMockResponse) && empty(self::$settings->saveMockResponse)) {
             $this->client->getEmitter()->attach($this->getMock($endpoint, $query));
         }
         if ($method == 'GET' || $method == 'DELETE') {
@@ -335,7 +335,7 @@ class RestClient {
         file_put_contents($filename, $data);
         if (self::$settings->debug) {
             $requestData = "<?\n\$reqdata = array('url' => '$requestUrl', \n'httpCode' => $httpCode, \n'body' => '$requestBody');";
-            $filename    = self::$settings->mockResponsesDir . md5($requestUrl) . md5($requestBody) . '.inc';
+            $filename    = self::$settings->mockResponsesDir . md5($requestUrl) . md5($requestBody) . '_req.inc';
             file_put_contents($filename, $requestData);
         }
     }

--- a/lib/client.php
+++ b/lib/client.php
@@ -206,7 +206,7 @@ class RestClient {
      * Wrapper around Guzzle request.
      *
      * @param string   $endpoint      API endpoint string
-     * @param string[] $query         Array of URLEncoded query items in key-value pairs.
+     * @param string[] $query         Query params.
      * @param bool     $customPostfix Use default REST postfix?
      * @param bool     $dwollaParse   Parse out of message envelope?
      *
@@ -289,6 +289,14 @@ class RestClient {
         $this->client = new Client($p);
     }
 
+    /**
+     * Getting Guzzle mock response.
+     *
+     * @param string   $requestUrl      Full API endpoint URL
+     * @param mixed    $requestBody     Request body.
+     *
+     * @return Mock    Guzzle mock response.
+     */
     private function getMock ($requestUrl, $requestBody) {
         if (!is_string($requestBody)) {
             $requestBody = print_r($requestBody, true);
@@ -317,6 +325,15 @@ class RestClient {
         return $mock;
     }
 
+    /**
+     * Saving Guzzle mock response.
+     *
+     * @param string   $requestUrl      Full API endpoint URL
+     * @param mixed    $requestBody     Request body.
+     * @param int      $httpCode        HTTP response code.
+     * @param array    $headers_source  HTTP headers array
+     * @param mixed    $response        Response body
+     */
     private function saveMock ($requestUrl, $requestBody, $httpCode, $headers_source, $response) {
         if (!file_exists(self::$settings->mockResponsesDir)) {
             mkdir(self::$settings->mockResponsesDir, 0777, true);

--- a/lib/client.php
+++ b/lib/client.php
@@ -214,7 +214,7 @@ class RestClient {
      */
     private function _send ($method, $endpoint, $query, $customPostfix = false, $dwollaParse = true) {
         if (!empty(self::$settings->useMockResponse) && empty(self::$settings->saveMockResponse)) {
-            $this->client->getEmitter()->attach($this->getMock($endpoint, $query));
+            $this->client->getEmitter()->attach($this->getMock($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, $query));
         }
         if ($method == 'GET' || $method == 'DELETE') {
             $configArray = ['query' => $query];
@@ -229,7 +229,9 @@ class RestClient {
                 $this->_console("$method Request to $endpoint\n");
                 $this->_console("    " . json_encode($query));
             }
-            $this->saveMock($endpoint, $query, $response->getStatusCode(), $response->getHeaders(), (string)$response->getBody());
+            if (!empty(self::$settings->saveMockResponse)) {
+                $this->saveMock($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, $query, $response->getStatusCode(), $response->getHeaders(), (string)$response->getBody());
+            }
         } catch (RequestException $exception) {
             $response    = false;
             $responseRaw = '';
@@ -242,7 +244,9 @@ class RestClient {
                     $responseRaw = $exception->getResponse();
                 }
             }
-            $this->saveMock($endpoint, $query, $exception->getCode(), array(), (string)$responseRaw);
+            if (!empty(self::$settings->saveMockResponse)) {
+                $this->saveMock($endpoint, $query, $exception->getCode(), array(), (string)$responseRaw);
+            }
         }
         if ($response) {
             if ($response->getBody()) {

--- a/lib/client.php
+++ b/lib/client.php
@@ -286,6 +286,7 @@ class RestClient {
     }
 
     private function getMock ($requestUrl, $requestBody) {
+        echo "Reading mock\n";
         if (!is_string($requestBody)) {
             $requestBody = print_r($requestBody, true);
         }
@@ -314,6 +315,7 @@ class RestClient {
     }
 
     private function saveMock ($requestUrl, $requestBody, $httpCode, $headers_source, $response) {
+        echo "Saving mock\n";
         if (!file_exists(self::$settings->mockResponsesDir)) {
             mkdir(self::$settings->mockResponsesDir, 0777, true);
         }

--- a/lib/client.php
+++ b/lib/client.php
@@ -6,17 +6,15 @@
  *  / _` \ \ /\ / / _ \| | |/ _` |
  * | (_| |\ V  V / (_) | | | (_| |
  *  \__,_| \_/\_/ \___/|_|_|\__,_|
-
  * An official Guzzle based wrapper for the Dwolla API.
-
  * Support is available on our forums at: https://discuss.dwolla.com/category/api-support
-
- * @package Dwolla
- * @author Dwolla (David Stancu): api@dwolla.com, david@dwolla.com
+ *
+ * @package   Dwolla
+ * @author    Dwolla (David Stancu): api@dwolla.com, david@dwolla.com
  * @copyright Copyright (C) 2014 Dwolla Inc.
- * @license  MIT (http://opensource.org/licenses/MIT)
- * @version 2.1.6
- * @link http://developers.dwolla.com
+ * @license   MIT (http://opensource.org/licenses/MIT)
+ * @version   2.1.6
+ * @link      http://developers.dwolla.com
  */
 
 namespace Dwolla;
@@ -27,6 +25,10 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Message\Response;
 use GuzzleHttp\Exception\RequestException;
+
+use GuzzleHttp\Subscriber\Mock;
+use GuzzleHttp\Stream\Stream;
+
 
 class RestClient {
 
@@ -48,19 +50,20 @@ class RestClient {
      * PHP "magic" getter.
      *
      * @param $name
+     *
      * @return $value
      */
-    public function __get($name) {
+    public function __get ($name) {
         return $this->$name;
     }
 
-   /**
+    /**
      * PHP "magic" setter.
      *
      * @param $name
      * @param $value
      */
-    public function __set($name, $value) {
+    public function __set ($name, $value) {
         $this->$name = $value;
     }
 
@@ -70,7 +73,7 @@ class RestClient {
      *
      * @param $data {???} Can be anything.
      */
-    protected function _logtofile($data) {
+    protected function _logtofile ($data) {
         if (!empty(self::$settings->logfilePath) && file_exists(self::$settings->logfilePath . "/")) {
             file_put_contents(
                 self::$settings->logfilePath . "/" . date("Y-m-d") . ".log",
@@ -85,8 +88,7 @@ class RestClient {
      *
      * @param $data {???} Can be anything.
      */
-    protected function _console($data)
-    {
+    protected function _console ($data) {
         if (self::$settings->debug) {
             if (self::$settings->browserMessages) {
                 print("<script>console.log(");
@@ -104,9 +106,10 @@ class RestClient {
      * Small error message wrapper for missing parameters, etc.
      *
      * @param string $message Error message.
+     *
      * @return bool
      */
-    protected function _error($message) {
+    protected function _error ($message) {
         print("DwollaPHP: " . $message);
         $this->_console("DwollaPHP: " . $message);
         return false;
@@ -119,10 +122,8 @@ class RestClient {
      *
      * @return String[] Data from API
      */
-    private function _dwollaparse($response)
-    {
-        if ($response['Success'] != true)
-        {
+    private function _dwollaparse ($response) {
+        if ($response['Success'] != true) {
             $this->_console("DwollaPHP: An API error was encountered.\nServer Message:\n");
             $this->_console($response['Message']);
             if ($response['Response']) {
@@ -130,8 +131,7 @@ class RestClient {
                 $this->_console($response['Response']);
             }
             return array('Error' => $response['Message']);
-        }
-        else {
+        } else {
             return $response['Response'];
         }
     }
@@ -142,179 +142,114 @@ class RestClient {
      *
      * @return string Host
      */
-    protected function _host() {
+    protected function _host () {
         return self::$settings->sandbox ? self::$settings->sandbox_host : self::$settings->production_host;
     }
 
     /**
      * Wrapper around Guzzle POST request.
      *
-     * @param string $endpoint API endpoint string
-     * @param string $request Request body. JSON encoding is optional.
-     * @param bool $customPostfix Use default REST postfix?
-     * @param bool $dwollaParse Parse out of message envelope?
+     * @param string $endpoint      API endpoint string
+     * @param string $request       Request body. JSON encoding is optional.
+     * @param bool   $customPostfix Use default REST postfix?
+     * @param bool   $dwollaParse   Parse out of message envelope?
      *
      * @return String[] Response body.
      */
-    protected function _post($endpoint, $request, $customPostfix = false, $dwollaParse = true) {
-        // First, we try to catch any errors as the request "goes out the door"
-        try {
-            $response = $this->client->post($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, ['json' => $request]);
-            if (self::$settings->debug){
-                $this->_console("POST Request to $endpoint\n");
-                $this->_console("    " . json_encode($request));
-            }
-        }
-        catch (RequestException $exception) {
-            $response = false;
-            if (self::$settings->debug){
-                $this->_console("DwollaPHP: An error has occurred during a POST request.\nRequest Body:\n");
-                $this->_console($exception->getRequest());
-                if ($exception->hasResponse()) {
-                    $this->_console("Server Response:\n");
-                    $this->_console($exception->getResponse());
-                }
-            }
-        }
-        if ($response) {
-            if ($response->getBody()) {
-                // If we get a response, we parse it out of the Dwolla envelope and catch API errors.
-                return $dwollaParse ? $this->_dwollaparse($response->json()) : $response->json();
-            }
-        }
-        else {
-            if (self::$settings->debug) {
-                $this->_console("DwollaPHP: An error has occurred; the response body is empty");
-            }
-            return null;
-        }
+    protected function _post ($endpoint, $request, $customPostfix = false, $dwollaParse = true) {
+        return $this->_send('POST', $endpoint, $request, $customPostfix, $dwollaParse);
     }
 
     /**
      * Wrapper around Guzzle PUT request.
      *
-     * @param string $endpoint API endpoint string
-     * @param string $request Request body. JSON encoding is optional.
-     * @param bool $customPostfix Use default REST postfix?
-     * @param bool $dwollaParse Parse out of message envelope?
+     * @param string $endpoint      API endpoint string
+     * @param string $request       Request body. JSON encoding is optional.
+     * @param bool   $customPostfix Use default REST postfix?
+     * @param bool   $dwollaParse   Parse out of message envelope?
      *
      * @return String[] Response body.
      */
-    protected function _put($endpoint, $request, $customPostfix = false, $dwollaParse = true) {
-        // First, we try to catch any errors as the request "goes out the door"
-        try {
-            $response = $this->client->put($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, ['json' => $request]);
-            if (self::$settings->debug){
-                $this->_console("PUT Request to $endpoint\n");
-                $this->_console("    " . json_encode($request));
-            }
-        }
-        catch (RequestException $exception) {
-            $response = false;
-            if (self::$settings->debug){
-                $this->_console("DwollaPHP: An error has occurred during a PUT request.\nRequest Body:\n");
-                $this->_console($exception->getRequest());
-                if ($exception->hasResponse()) {
-                    $this->_console("Server Response:\n");
-                    $this->_console($exception->getResponse());
-                }
-            }
-        }
-        if ($response) {
-            if ($response->getBody()) {
-                // If we get a response, we parse it out of the Dwolla envelope and catch API errors.
-                return $dwollaParse ? $this->_dwollaparse($response->json()) : $response->json();
-            }
-        }
-        else {
-            if (self::$settings->debug) {
-                $this->_console("DwollaPHP: An error has occurred; the response body is empty");
-            }
-            return null;
-        }
-    }    
+    protected function _put ($endpoint, $request, $customPostfix = false, $dwollaParse = true) {
+        return $this->_send('PUT', $endpoint, $request, $customPostfix, $dwollaParse);
+    }
 
     /**
      * Wrapper around Guzzle GET request.
      *
-     * @param string $endpoint API endpoint string
-     * @param string[] $query Array of URLEncoded query items in key-value pairs.
-     * @param bool $customPostfix Use default REST postfix?
-     * @param bool $dwollaParse Parse out of message envelope?
+     * @param string   $endpoint      API endpoint string
+     * @param string[] $query         Array of URLEncoded query items in key-value pairs.
+     * @param bool     $customPostfix Use default REST postfix?
+     * @param bool     $dwollaParse   Parse out of message envelope?
      *
      * @return string[] Response body.
      */
-    protected function _get($endpoint, $query, $customPostfix = false, $dwollaParse = true) {
-        // First, we try to catch any errors as the request "goes out the door"
-        try {
-            $response = $this->client->get($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, ['query' => $query]);
-            if (self::$settings->debug){
-                $this->_console("GET Request to $endpoint\n");
-                $this->_console("    " . json_encode($query));
-            }
-        }
-        catch (RequestException $exception) {
-            $response = false;
-            if (self::$settings->debug){
-                $this->_console("DwollaPHP: An error has occurred during a GET request.\nRequest Body:\n");
-                $this->_console($exception->getRequest());
-                if ($exception->hasResponse()) {
-                    $this->_console("Server Response:\n");
-                    $this->_console($exception->getResponse());
-                }
-            }
-        }
-        if ($response) {
-            if ($response->getBody()) {
-                // If we get a response, we parse it out of the Dwolla envelope and catch API errors.
-                return $dwollaParse ? $this->_dwollaparse($response->json()) : $response->json();
-            }
-        }
-        else {
-            if (self::$settings->debug) {
-                $this->_console("DwollaPHP: An error has occurred; the response body is empty");
-            }
-            return null;
-        }
+    protected function _get ($endpoint, $query, $customPostfix = false, $dwollaParse = true) {
+        return $this->_send('GET', $endpoint, $query, $customPostfix, $dwollaParse);
     }
 
     /**
      * Wrapper around Guzzle DELETE request.
      *
-     * @param string $endpoint API endpoint string
-     * @param string[] $query Array of URLEncoded query items in key-value pairs.
-     * @param bool $customPostfix Use default REST postfix?
-     * @param bool $dwollaParse Parse out of message envelope?
+     * @param string   $endpoint      API endpoint string
+     * @param string[] $query         Array of URLEncoded query items in key-value pairs.
+     * @param bool     $customPostfix Use default REST postfix?
+     * @param bool     $dwollaParse   Parse out of message envelope?
      *
      * @return string[] Response body.
      */
-    protected function _delete($endpoint, $query, $customPostfix = false, $dwollaParse = true) {
+    protected function _delete ($endpoint, $query, $customPostfix = false, $dwollaParse = true) {
+        return $this->_send('DELETE', $endpoint, $query, $customPostfix, $dwollaParse);
+    }
+
+    /**
+     * Wrapper around Guzzle request.
+     *
+     * @param string   $endpoint      API endpoint string
+     * @param string[] $query         Array of URLEncoded query items in key-value pairs.
+     * @param bool     $customPostfix Use default REST postfix?
+     * @param bool     $dwollaParse   Parse out of message envelope?
+     *
+     * @return string[] Response body.
+     */
+    private function _send ($method, $endpoint, $query, $customPostfix = false, $dwollaParse = true) {
+        if (!empty(self::$settings->useMockResponse)) {
+            $this->client->getEmitter()->attach($this->getMock($endpoint, $query));
+        }
+        if ($method == 'GET' || $method == 'DELETE') {
+            $configArray = ['query' => $query];
+        } else {
+            $configArray = ['json' => $query];
+        }
+        $request = $this->client->createRequest($method, $this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, $configArray);
         // First, we try to catch any errors as the request "goes out the door"
         try {
-            $response = $this->client->delete($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, ['query' => $query]);
-            if (self::$settings->debug){
-                $this->_console("DELETE Request to $endpoint\n");
+            $response = $this->client->send($request, ['timeout' => 2]);
+            if (self::$settings->debug) {
+                $this->_console("$method Request to $endpoint\n");
                 $this->_console("    " . json_encode($query));
             }
-        }
-        catch (RequestException $exception) {
-            $response = false;
-            if (self::$settings->debug){
-                $this->_console("DwollaPHP: An error has occurred during a DELETE request.\nRequest Body:\n");
+            $this->saveMock($endpoint, $query, $response->getStatusCode(), $response->getHeaders(), (string)$response->getBody());
+        } catch (RequestException $exception) {
+            $response    = false;
+            $responseRaw = '';
+            if (self::$settings->debug) {
+                $this->_console("DwollaPHP: An error has occurred during a $method request.\nRequest Body:\n");
                 $this->_console($exception->getRequest());
                 if ($exception->hasResponse()) {
                     $this->_console("Server Response:\n");
                     $this->_console($exception->getResponse());
+                    $responseRaw = $exception->getResponse();
                 }
             }
+            $this->saveMock($endpoint, $query, $exception->getCode(), array(), (string)$responseRaw);
         }
         if ($response) {
             if ($response->getBody()) {
                 // If we get a response, we parse it out of the Dwolla envelope and catch API errors.
                 return $dwollaParse ? $this->_dwollaparse($response->json()) : $response->json();
             }
-        }
-        else {
+        } else {
             if (self::$settings->debug) {
                 $this->_console("DwollaPHP: An error has occurred; the response body is empty");
             }
@@ -325,27 +260,85 @@ class RestClient {
     /**
      * Constructor. Takes no arguments.
      */
-    public function __construct() {
+    public function __construct () {
 
-        self::$settings = new Settings();
-        self::$settings->host = self::$settings->sandbox ?  self::$settings->sandbox_host : self::$settings->production_host;
+        self::$settings       = new Settings();
+        self::$settings->host = self::$settings->sandbox ? self::$settings->sandbox_host : self::$settings->production_host;
 
         $this->settings = self::$settings;
 
         $p = [
             'defaults' => [
                 'headers' =>
-                            [
-                                'Content-Type' => 'application/json',
-                                'User-Agent' => 'dwolla-php/2'
-                            ],
+                    [
+                        'Content-Type' => 'application/json',
+                        'User-Agent'   => 'dwolla-php/2'
+                    ],
                 'timeout' => self::$settings->rest_timeout
             ]
         ];
 
-        if (self::$settings->proxy) { $p['proxy'] = self::$settings->proxy; }
+        if (self::$settings->proxy) {
+            $p['proxy'] = self::$settings->proxy;
+        }
 
         $this->client = new Client($p);
     }
+
+    private function getMock ($requestUrl, $requestBody) {
+        if (!is_string($requestBody)) {
+            $requestBody = print_r($requestBody, true);
+        }
+        $filename = self::$settings->mockResponsesDir . md5($requestUrl) . md5($requestBody) . '.inc';
+        if (file_exists($filename)) {
+            $data = null;
+            require $filename;
+            $data['headers'] = (array)json_decode(htmlspecialchars_decode($data['headers_json'], ENT_QUOTES));
+            $mockResponse    = new Response($data['httpCode']);
+            $mockResponse->setHeaders($data['headers']);
+            $separator = "\r\n\r\n";
+            $bodyParts = explode($separator, htmlspecialchars_decode($data['response']), ENT_QUOTES);
+            if (count($bodyParts) > 1) {
+                $mockResponse->setBody(Stream::factory($bodyParts[count($bodyParts) - 1]));
+            } else {
+                $mockResponse->setBody(Stream::factory(htmlspecialchars_decode($data['response'])));
+            }
+            $mock = new Mock([
+                $mockResponse
+            ]);
+        } else {
+            $mockResponse = new Response(404);
+            $mock         = new Mock([$mockResponse]);
+        }
+        return $mock;
+    }
+
+    private function saveMock ($requestUrl, $requestBody, $httpCode, $headers_source, $response) {
+        if (!file_exists(self::$settings->mockResponsesDir)) {
+            mkdir(self::$settings->mockResponsesDir, 0777, true);
+        }
+        if (!is_string($requestBody)) {
+            $requestBody = print_r($requestBody, true);
+        }
+        $headers = array();
+        foreach ($headers_source as $name => $value) {
+            if (is_array($value)) {
+                $headers[$name] = $value[0];
+            } else {
+                $headers[$name] = $value;
+            }
+        }
+        $response     = htmlspecialchars($response, ENT_QUOTES);
+        $headers_json = htmlspecialchars(json_encode($headers), ENT_QUOTES);
+        $data         = "<?\n\$data = array('headers_json' => '$headers_json', \n'httpCode' => $httpCode, \n'response' => '$response');";
+        $filename     = self::$settings->mockResponsesDir . md5($requestUrl) . md5($requestBody) . '.inc';
+        file_put_contents($filename, $data);
+        if (self::$settings->debug) {
+            $requestData = "<?\n\$reqdata = array('url' => '$requestUrl', \n'httpCode' => $httpCode, \n'body' => '$requestBody');";
+            $filename    = self::$settings->mockResponsesDir . md5($requestUrl) . md5($requestBody) . '.inc';
+            file_put_contents($filename, $requestData);
+        }
+    }
+
 }
 

--- a/lib/client.php
+++ b/lib/client.php
@@ -245,7 +245,7 @@ class RestClient {
                 }
             }
             if (!empty(self::$settings->saveMockResponse)) {
-                $this->saveMock($endpoint, $query, $exception->getCode(), array(), (string)$responseRaw);
+                $this->saveMock($this->_host() . ($customPostfix ? $customPostfix : self::$settings->default_postfix) . $endpoint, $query, $exception->getCode(), array(), (string)$responseRaw);
             }
         }
         if ($response) {

--- a/lib/client.php
+++ b/lib/client.php
@@ -286,7 +286,6 @@ class RestClient {
     }
 
     private function getMock ($requestUrl, $requestBody) {
-        echo "Reading mock\n";
         if (!is_string($requestBody)) {
             $requestBody = print_r($requestBody, true);
         }
@@ -315,7 +314,6 @@ class RestClient {
     }
 
     private function saveMock ($requestUrl, $requestBody, $httpCode, $headers_source, $response) {
-        echo "Saving mock\n";
         if (!file_exists(self::$settings->mockResponsesDir)) {
             mkdir(self::$settings->mockResponsesDir, 0777, true);
         }


### PR DESCRIPTION
As discussed in an issue #60 I've adjusted your code to save real responses to files and mock them on request for unit test purposes.

**Additional settings**
- `$useMockResponse` - tells if system should look for local response file instead of making a real query (if the system is in unit tests mode);
- `$saveMockResponse` - tells if system is under unit tests but should make a real query and save the response;
- `$mockResponsesDir` - a folder to store local responses.

I've changed all request functions to be layers to `_send` function which can either send a real query or read a mock (and also save a mock if needed).

`getMock` function gets a saved response for a specified API URL and request body. If no local file found it returns 404 error.

`saveMock` function saves an array with response code, headers and body to a file.

Functions are tested and working fine. But I didn't do any unit tests for newly added functions. Let me know if you want to improve something.